### PR TITLE
fix: install wrapper dependencies with test automation

### DIFF
--- a/.github/workflows/pytest-actions.yaml
+++ b/.github/workflows/pytest-actions.yaml
@@ -25,7 +25,7 @@ jobs:
           python -m pip install -r requirements.txt
       - name: Install dbdicom
         run: |
-          python -m pip install -e .
+          python -m pip install -e .[wrappers]
       - name: Test with pytest
         run: |
           python -m pip install pytest pytest-cov

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ docs = [
 ]
 wrappers = [
     "scipy",
-    "skimage",
+    "scikit-image",
     "SimpleITK", "itk-elastix",
     "dipy",
 ]


### PR DESCRIPTION
Update pytest-actions.yaml to install optional dependencies for wrappers in development mode. Additionally change 'skimage' to 'scikit-image' to correctly install skimage package without error