### PR TITLE
Fix: zero-fill TM strings to avoid error

### DIFF
--- a/src/dbdicom/utils/variables.py
+++ b/src/dbdicom/utils/variables.py
@@ -12,7 +12,7 @@ def str_to_seconds(dicom_tm):
     # Convert the fractional seconds to a decimal
     fractional_seconds = float('.' + fractional_seconds)
     # Create a datetime object representing the time
-    seconds_since_midnight = (hours * 3600).zfill(2) + (minutes * 60) + seconds + fractional_seconds
+    seconds_since_midnight = (hours * 3600) + (minutes * 60) + seconds + fractional_seconds
     return seconds_since_midnight
 
 def seconds_to_str(seconds_since_midnight):
@@ -21,8 +21,8 @@ def seconds_to_str(seconds_since_midnight):
     seconds = math.floor(seconds_since_midnight-hours*3600-minutes*60)
     fractional_seconds = round(seconds_since_midnight-hours*3600-minutes*60-seconds, 6)
     hours = str(hours).zfill(2)
-    minutes = str(minutes)
-    seconds = str(seconds)
+    minutes = str(minutes).zfill(2)
+    seconds = str(seconds).zfill(2)
     fractional_seconds = str(fractional_seconds)
     _, fractional_seconds = fractional_seconds.split('.')
     fractional_seconds = fractional_seconds.ljust(6,'0')
@@ -50,8 +50,8 @@ def time_to_str(tm):
     seconds = tm.second
     fractional_seconds = tm.microsecond / 1000000.0   
     hours = str(hours).zfill(2)
-    minutes = str(minutes)
-    seconds = str(seconds)
+    minutes = str(minutes).zfill(2)
+    seconds = str(seconds).zfill(2)
     fractional_seconds = str(fractional_seconds)
     _, fractional_seconds = fractional_seconds.split('.')
     fractional_seconds = fractional_seconds.ljust(6,'0')
@@ -69,16 +69,7 @@ def datetime_to_str(dt):
     return date + time
 
 
-
-if __name__ == "__main__":
-
-    sec = 13*60*60 + 12*60 + 40 + 0.03
-    dcm = '131240.030000'
-    tim = datetime.time(13, 12, 40, 30000)
-    date = datetime.date(2023, 3, 1)
-    date_str = '20230301'
-    dt = datetime.datetime(2023, 3, 1, 13, 12, 40, 30000)
-    dt_str = '20230301131240.030000'
+def test_all_conversions(sec, dcm, tim, date, date_str, dt, dt_str):
 
     assert str_to_seconds(dcm) == sec
     assert seconds_to_str(sec) == dcm
@@ -91,5 +82,54 @@ if __name__ == "__main__":
     assert date_to_str(date) == date_str
     assert time_to_str(tim) == dcm
     assert datetime_to_str(dt) == dt_str
+    
 
-    print('Module passed all tests')
+def test_module():
+
+    sec = 13*60*60 + 12*60 + 40 + 0.03
+    dcm = '131240.030000'
+    tim = datetime.time(13, 12, 40, 30000)
+    date = datetime.date(2023, 3, 1)
+    date_str = '20230301'
+    dt = datetime.datetime(2023, 3, 1, 13, 12, 40, 30000)
+    dt_str = '20230301131240.030000'
+
+    test_all_conversions(sec, dcm, tim, date, date_str, dt, dt_str)
+
+    sec = 7*60*60 + 12*60 + 40 + 0.03
+    dcm = '071240.030000'
+    tim = datetime.time(7, 12, 40, 30000)
+    date = datetime.date(2023, 3, 1)
+    date_str = '20230301'
+    dt = datetime.datetime(2023, 3, 1, 7, 12, 40, 30000)
+    dt_str = '20230301071240.030000'
+
+    test_all_conversions(sec, dcm, tim, date, date_str, dt, dt_str)
+
+    sec = 7*60*60 + 3*60 + 40 + 0.03
+    dcm = '070340.030000'
+    tim = datetime.time(7, 3, 40, 30000)
+    date = datetime.date(2023, 3, 1)
+    date_str = '20230301'
+    dt = datetime.datetime(2023, 3, 1, 7, 3, 40, 30000)
+    dt_str = '20230301070340.030000'
+
+    test_all_conversions(sec, dcm, tim, date, date_str, dt, dt_str)
+
+    sec = 7*60*60 + 3*60 + 4 + 0.03
+    dcm = '070304.030000'
+    tim = datetime.time(7, 3, 4, 30000)
+    date = datetime.date(2023, 3, 1)
+    date_str = '20230301'
+    dt = datetime.datetime(2023, 3, 1, 7, 3, 4, 30000)
+    dt_str = '20230301070304.030000'   
+
+    test_all_conversions(sec, dcm, tim, date, date_str, dt, dt_str) 
+
+    print('dbdicom.utils.variables passed all tests')
+
+
+if __name__ == "__main__":
+
+    test_module()
+

--- a/src/dbdicom/utils/variables.py
+++ b/src/dbdicom/utils/variables.py
@@ -12,7 +12,7 @@ def str_to_seconds(dicom_tm):
     # Convert the fractional seconds to a decimal
     fractional_seconds = float('.' + fractional_seconds)
     # Create a datetime object representing the time
-    seconds_since_midnight = (hours * 3600) + (minutes * 60) + seconds + fractional_seconds
+    seconds_since_midnight = (hours * 3600).zfill(2) + (minutes * 60) + seconds + fractional_seconds
     return seconds_since_midnight
 
 def seconds_to_str(seconds_since_midnight):
@@ -20,7 +20,7 @@ def seconds_to_str(seconds_since_midnight):
     minutes = math.floor((seconds_since_midnight-hours*3600)/60)
     seconds = math.floor(seconds_since_midnight-hours*3600-minutes*60)
     fractional_seconds = round(seconds_since_midnight-hours*3600-minutes*60-seconds, 6)
-    hours = str(hours)
+    hours = str(hours).zfill(2)
     minutes = str(minutes)
     seconds = str(seconds)
     fractional_seconds = str(fractional_seconds)
@@ -49,7 +49,7 @@ def time_to_str(tm):
     minutes = tm.minute
     seconds = tm.second
     fractional_seconds = tm.microsecond / 1000000.0   
-    hours = str(hours)
+    hours = str(hours).zfill(2)
     minutes = str(minutes)
     seconds = str(seconds)
     fractional_seconds = str(fractional_seconds)


### PR DESCRIPTION
DICOM VR TM is searching for strings formatted with 6 places before the decimal point, i.e. HHMMSS. The datetime-to-string conversion functions in the variables.py script therefore currently result in errors when the hours fall below 10, because this outputs string values of the format HMMSS (e.g., ValueError: Unable to convert non-conformant value '11405.247000' to 'TM' object)

Adding zero filling to the hours strings to fix this issue.